### PR TITLE
Use a better tempdir, fix some documentation, and make json test more readable

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -4,62 +4,9 @@
 # =========================================================================
 
 use 5.008_001;
-
 use strict;
-use warnings;
-use utf8;
 
-use Module::Build;
-use File::Basename;
-use File::Spec;
+use Module::Build::Tiny 0.035;
 
-my %args = (
-    license              => 'perl',
-    dynamic_config       => 0,
-
-    configure_requires => {
-        'Module::Build' => 0.38,
-    },
-
-    name            => 'HTTP-Entity-Parser',
-    module_name     => 'HTTP::Entity::Parser',
-    allow_pureperl => 0,
-
-    script_files => [glob('script/*'), glob('bin/*')],
-    c_source     => [qw()],
-    PL_files => {},
-
-    test_files           => ((-d '.git' || $ENV{RELEASE_TESTING}) && -d 'xt') ? 't/ xt/' : 't/',
-    recursive_test_files => 1,
-
-
-);
-if (-d 'share') {
-    $args{share_dir} = 'share';
-}
-
-my $builder = Module::Build->subclass(
-    class => 'MyBuilder',
-    code => q{
-        sub ACTION_distmeta {
-            die "Do not run distmeta. Install Minilla and `minil install` instead.\n";
-        }
-        sub ACTION_installdeps {
-            die "Do not run installdeps. Run `cpanm --installdeps .` instead.\n";
-        }
-    }
-)->new(%args);
-$builder->create_build_script();
-
-use File::Copy;
-
-print "cp META.json MYMETA.json\n";
-copy("META.json","MYMETA.json") or die "Copy failed(META.json): $!";
-
-if (-f 'META.yml') {
-    print "cp META.yml MYMETA.yml\n";
-    copy("META.yml","MYMETA.yml") or die "Copy failed(META.yml): $!";
-} else {
-    print "There is no META.yml... You may install this module from the repository...\n";
-}
+Build_PL();
 

--- a/META.json
+++ b/META.json
@@ -4,13 +4,13 @@
       "Masahiro Nagano <kazeburo@gmail.com>"
    ],
    "dynamic_config" : 0,
-   "generated_by" : "Minilla/v2.4.1, CPAN::Meta::Converter version 2.150005",
+   "generated_by" : "Minilla/v3.0.4, CPAN::Meta::Converter version 2.150010",
    "license" : [
       "perl_5"
    ],
    "meta-spec" : {
       "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
-      "version" : "2"
+      "version" : 2.0
    },
    "name" : "HTTP-Entity-Parser",
    "no_index" : {
@@ -28,7 +28,7 @@
    "prereqs" : {
       "configure" : {
          "requires" : {
-            "Module::Build" : "0.38"
+            "Module::Build::Tiny" : "0.035"
          }
       },
       "develop" : {
@@ -45,7 +45,8 @@
             "Encode" : "0",
             "File::Temp" : "0",
             "HTTP::MultiPartParser" : "0",
-            "JSON" : "2",
+            "Hash::MultiValue" : "0",
+            "JSON::MaybeXS" : "1.003007",
             "Module::Load" : "0",
             "Stream::Buffered" : "0",
             "WWW::Form::UrlEncoded" : "0.23",
@@ -60,7 +61,6 @@
             "Cwd" : "0",
             "File::Spec::Functions" : "0",
             "HTTP::Message" : "6",
-            "Hash::MultiValue" : "0",
             "Test::More" : "0.98"
          }
       }
@@ -79,7 +79,8 @@
    },
    "version" : "0.17",
    "x_contributors" : [
-      "moznion <moznion@gmail.com>"
+      "moznion <moznion@gmail.com>",
+      "Karen Etheridge <ether@cpan.org>"
    ],
-   "x_serialization_backend" : "JSON::PP version 2.27203"
+   "x_serialization_backend" : "JSON::MaybeXS version 1.003007"
 }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ HTTP::Entity::Parser - PSGI compliant HTTP Entity Parser
 # SYNOPSIS
 
     use HTTP::Entity::Parser;
-    
+
     my $parser = HTTP::Entity::Parser->new;
     $parser->register('application/x-www-form-urlencoded','HTTP::Entity::Parser::UrlEncoded');
     $parser->register('multipart/form-data','HTTP::Entity::Parser::MultiPart');
@@ -18,10 +18,10 @@ HTTP::Entity::Parser - PSGI compliant HTTP Entity Parser
 
 # DESCRIPTION
 
-HTTP::Entity::Parser is PSGI compliant HTTP Entity parser. This module also has compatibility 
-with [HTTP::Body](https://metacpan.org/pod/HTTP::Body). Unlike HTTP::Body, HTTP::Entity::Parser reads HTTP entity from 
-PSGI's env `$env->{'psgi.input'}` and parse it.
-This module support application/x-www-form-urlencoded, multipart/form-data and application/json.
+HTTP::Entity::Parser is a PSGI-compliant HTTP Entity parser. This module also is compatible
+with [HTTP::Body](https://metacpan.org/pod/HTTP::Body). Unlike HTTP::Body, HTTP::Entity::Parser reads HTTP entities from
+PSGI's environment `$env->{'psgi.input'}` and parses it.
+This module supports application/x-www-form-urlencoded, multipart/form-data and application/json.
 
 # METHODS
 
@@ -31,7 +31,7 @@ This module support application/x-www-form-urlencoded, multipart/form-data and a
 
     - buffer\_length
 
-        buffer length, HTTP::Entity::Parser read from psgi.input. 16384 by default.
+        The buffer length that HTTP::Entity::Parser reads from psgi.input. 16384 by default.
 
 - register($content\_type:String, $class:String, $opts:HashRef)
 
@@ -41,27 +41,27 @@ This module support application/x-www-form-urlencoded, multipart/form-data and a
         $parser->register('multipart/form-data','HTTP::Entity::Parser::MultiPart');
         $parser->register('application/json','HTTP::Entity::Parser::JSON');
 
-    If the request content\_type match registered type, HTTP::Entity::Parser uses registered 
+    If the request content\_type matches the registered type, HTTP::Entity::Parser uses the registered
     parser class. If content\_type does not match any registered type, HTTP::Entity::Parser::OctetStream is used.
 
 - parse($env:HashRef)
 
-    parse HTTP entity from PSGI's env.
+    parse HTTP entities from PSGI's env.
 
         my ( $params:ArrayRef, $uploads:ArrayRef) = $parser->parse($env);
 
-    `$param` is key-value pair list.
+    `$param` is a key-value pair list.
 
         my ( $params, $uploads) = $parser->parse($env);
         my $body_parameters = Hash::MultiValue->new(@$params);
 
-    `$uploads` is ArrayRef of HashRef.
+    `$uploads` is an ArrayRef of HashRef.
 
         my ( $params, $uploads) = $parser->parse($env);
         warn Dumper($uploads->[0]);
         {
             "name" => "upload", #field name
-            "headeres" => [
+            "headers" => [
                 "Content-Type" => "application/octet-stream",
                 "Content-Disposition" => "form-data; name=\"upload\"; filename=\"hello.pl\""           
             ],
@@ -70,7 +70,7 @@ This module support application/x-www-form-urlencoded, multipart/form-data and a
             "tempname" => "/tmp/XXXXX", # path to the temporary file where uploaded file is saved
         }
 
-    use with Plack::Request::Upload
+    When used with [Plack::Request::Upload](https://metacpan.org/pod/Plack::Request::Upload):
 
         my ( $params, $uploads) = $parser->parse($env);
          my $upload_hmv = Hash::MultiValue->new();
@@ -98,9 +98,9 @@ This module support application/x-www-form-urlencoded, multipart/form-data and a
 
 - JSON
 
-    For `application/json`. This parser decode JSON body automatically. 
+    For `application/json`. This parser decodes JSON body automatically.
 
-    It is convenient to use with Ajax form.
+    It is convenient to use with Ajax forms.
 
 # WHAT'S DIFFERENT FROM HTTP::Body
 

--- a/cpanfile
+++ b/cpanfile
@@ -1,7 +1,7 @@
 requires 'perl', '5.008001';
 requires 'Stream::Buffered';
 requires 'Module::Load';
-requires 'JSON' => '2';
+requires 'JSON::MaybeXS' => '1.003007';
 requires 'Encode';
 requires 'HTTP::MultiPartParser';
 requires 'File::Temp';

--- a/cpanfile
+++ b/cpanfile
@@ -7,10 +7,10 @@ requires 'HTTP::MultiPartParser';
 requires 'File::Temp';
 requires 'WWW::Form::UrlEncoded', '0.23';
 suggests 'WWW::Form::UrlEncoded::XS', '0.23';
+requires 'Hash::MultiValue';
 
 on 'test' => sub {
     requires 'Test::More', '0.98';
-    requires 'Hash::MultiValue';
     requires 'File::Spec::Functions';
     requires 'Cwd';
     requires 'HTTP::Message' => 6;

--- a/lib/HTTP/Entity/Parser.pm
+++ b/lib/HTTP/Entity/Parser.pm
@@ -134,7 +134,7 @@ HTTP::Entity::Parser - PSGI compliant HTTP Entity Parser
 =head1 SYNOPSIS
 
     use HTTP::Entity::Parser;
-    
+
     my $parser = HTTP::Entity::Parser->new;
     $parser->register('application/x-www-form-urlencoded','HTTP::Entity::Parser::UrlEncoded');
     $parser->register('multipart/form-data','HTTP::Entity::Parser::MultiPart');
@@ -147,11 +147,10 @@ HTTP::Entity::Parser - PSGI compliant HTTP Entity Parser
 
 =head1 DESCRIPTION
 
-HTTP::Entity::Parser is PSGI compliant HTTP Entity parser. This module also has compatibility 
-with L<HTTP::Body>. Unlike HTTP::Body, HTTP::Entity::Parser reads HTTP entity from 
-PSGI's env C<$env-E<gt>{'psgi.input'}> and parse it.
-This module support application/x-www-form-urlencoded, multipart/form-data and application/json.
-
+HTTP::Entity::Parser is a PSGI-compliant HTTP Entity parser. This module also is compatible
+with L<HTTP::Body>. Unlike HTTP::Body, HTTP::Entity::Parser reads HTTP entities from
+PSGI's environment C<< $env->{'psgi.input'} >> and parses it.
+This module supports application/x-www-form-urlencoded, multipart/form-data and application/json.
 
 =head1 METHODS
 
@@ -165,7 +164,7 @@ Create the instance.
 
 =item buffer_length
 
-buffer length, HTTP::Entity::Parser read from psgi.input. 16384 by default.
+The buffer length that HTTP::Entity::Parser reads from psgi.input. 16384 by default.
 
 =back
 
@@ -177,27 +176,27 @@ Register parser class.
   $parser->register('multipart/form-data','HTTP::Entity::Parser::MultiPart');
   $parser->register('application/json','HTTP::Entity::Parser::JSON');
 
-If the request content_type match registered type, HTTP::Entity::Parser uses registered 
+If the request content_type matches the registered type, HTTP::Entity::Parser uses the registered
 parser class. If content_type does not match any registered type, HTTP::Entity::Parser::OctetStream is used.
 
 =item parse($env:HashRef)
 
-parse HTTP entity from PSGI's env.
+parse HTTP entities from PSGI's env.
 
   my ( $params:ArrayRef, $uploads:ArrayRef) = $parser->parse($env);
 
-C<$param> is key-value pair list.
+C<$param> is a key-value pair list.
 
    my ( $params, $uploads) = $parser->parse($env);
    my $body_parameters = Hash::MultiValue->new(@$params);
 
-C<$uploads> is ArrayRef of HashRef.
+C<$uploads> is an ArrayRef of HashRef.
 
    my ( $params, $uploads) = $parser->parse($env);
    warn Dumper($uploads->[0]);
    {
        "name" => "upload", #field name
-       "headeres" => [
+       "headers" => [
            "Content-Type" => "application/octet-stream",
            "Content-Disposition" => "form-data; name=\"upload\"; filename=\"hello.pl\""           
        ],
@@ -206,7 +205,7 @@ C<$uploads> is ArrayRef of HashRef.
        "tempname" => "/tmp/XXXXX", # path to the temporary file where uploaded file is saved
    }
 
-use with Plack::Request::Upload
+When used with L<Plack::Request::Upload>:
 
    my ( $params, $uploads) = $parser->parse($env);
     my $upload_hmv = Hash::MultiValue->new();
@@ -238,9 +237,9 @@ MultiPart parser use L<HTTP::MultiPartParser>.
 
 =item JSON
 
-For C<application/json>. This parser decode JSON body automatically. 
+For C<application/json>. This parser decodes JSON body automatically.
 
-It is convenient to use with Ajax form.
+It is convenient to use with Ajax forms.
 
 =back
 

--- a/lib/HTTP/Entity/Parser/JSON.pm
+++ b/lib/HTTP/Entity/Parser/JSON.pm
@@ -2,7 +2,7 @@ package HTTP::Entity::Parser::JSON;
 
 use strict;
 use warnings;
-use JSON qw//;
+use JSON::MaybeXS qw/decode_json/;
 use Encode qw/encode_utf8/;
 
 sub new {
@@ -19,7 +19,7 @@ sub add {
 sub finalize {
     my $self = shift;
 
-    my $p = JSON::decode_json($self->[0]);
+    my $p = decode_json($self->[0]);
     my @params;
     if (ref $p eq 'HASH') {
         while (my ($k, $v) = each %$p) {

--- a/lib/HTTP/Entity/Parser/MultiPart.pm
+++ b/lib/HTTP/Entity/Parser/MultiPart.pm
@@ -98,8 +98,7 @@ sub new {
             if ( defined $disposition_filename ) {
                 $part->{filename} = $disposition_filename;
                 $self->{tempdir} ||= do {
-                    my $template = File::Spec->catdir(File::Spec->tmpdir, "HTTP-Entity-Parser-MultiPart-XXXXX");
-                    my $dir = File::Temp->newdir($template, CLEANUP => 1);
+                    my $dir = File::Temp->newdir('XXXXX', TMPDIR => 1, CLEANUP => 1);
                     # Temporary dirs will remove after the request.
                     push @{$env->{'http.entity.parser.multipart.tempdir'}}, $dir;
                     $dir;

--- a/t/01_content_type/json.t
+++ b/t/01_content_type/json.t
@@ -3,6 +3,7 @@ use warnings;
 use Test::More;
 use HTTP::Entity::Parser::JSON;
 use Hash::MultiValue;
+use utf8;
 
 my $parser = HTTP::Entity::Parser::JSON->new();
 $parser->add('{');
@@ -16,7 +17,7 @@ is_deeply(Hash::MultiValue->new(@$params)->as_hashref_multi,
   +{
     'hoge'     => [ 'fuga', 'hige' ],
     'moge'     => ['muga'],
-    'にほんご' => ['日本語'],
+    Encode::encode_utf8('にほんご') => [Encode::encode_utf8('日本語')],
   });
 is_deeply $uploads, [];
 

--- a/t/01_content_type/url_encoded.t
+++ b/t/01_content_type/url_encoded.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Test::More;
 use HTTP::Entity::Parser::UrlEncoded;
-use JSON;
+use JSON::MaybeXS;
 
 while (<DATA>) {
     chomp;
@@ -12,7 +12,7 @@ while (<DATA>) {
     my $parser = HTTP::Entity::Parser::UrlEncoded->new();
     $parser->add($s);
     my ($params, $uploads) = $parser->finalize();
-    is JSON::encode_json($params), $t, $s;
+    is encode_json($params), $t, $s;
     is_deeply $uploads, [];
 }
 


### PR DESCRIPTION
I found a directory being left behind called /tmp/HTTP-Entity-Parser-MultiPart-TVRlb, which another process can find and try to read.