### PR TITLE
Relax minimum perl version to 5.8.1

### DIFF
--- a/lib/HTTP/Entity/Parser.pm
+++ b/lib/HTTP/Entity/Parser.pm
@@ -1,6 +1,6 @@
 package HTTP::Entity::Parser;
 
-use 5.008005;
+use 5.008001;
 use strict;
 use warnings;
 use Stream::Buffered;


### PR DESCRIPTION
Currently HTTP-Entity-Parser requires perl 5.8.5, but actually it works fine with perl 5.8.1.
```
❯ perl -v
This is perl, v5.8.1 built for darwin-2level

❯ perl -i -pe 's/use 5.008005/use 5.008001/' lib/HTTP/Entity/Parser.pm

❯ prove -lr t
t/00_compile.t ........................... ok
t/01_content_type/json.t ................. ok
t/01_content_type/multipart.t ............ ok
t/01_content_type/multipart_form_data.t .. ok
t/01_content_type/url_encoded.t .......... ok
t/02_http_body/multipart.t ............... ok
t/02_http_body/octetstream.t ............. ok
t/02_http_body/urlencoded.t .............. ok
All tests successful.
Files=8, Tests=272,  1 wallclock secs ( 0.06 usr  0.02 sys +  0.50 cusr  0.09 csys =  0.67 CPU)
Result: PASS
```

In the dependencies of Plack, only HTTP-Entity-Parser requires perl 5.8.5.
If HTTP-Entity-Parser relaxes minimum perl version to 5.8.1, we can install Plack to perl 5.8.1.
So I think it is worth relaxing  minimum perl version to 5.8.1 in HTTP-Entity-Parser.