### PR TITLE
Do not stringify nested hash references in JSON

### DIFF
--- a/lib/HTTP/Entity/Parser/JSON.pm
+++ b/lib/HTTP/Entity/Parser/JSON.pm
@@ -27,8 +27,10 @@ sub finalize {
                 for (@$v) {
                     push @params, encode_utf8($k), encode_utf8($_);
                 }
+            } elsif (ref $v) {
+                push @params, encode_utf8($k), $v;
             } else {
-                push @params, encode_utf8($k), encode_utf8($v); 
+                push @params, encode_utf8($k), encode_utf8($v);
             }
         }
     }
@@ -48,7 +50,7 @@ HTTP::Entity::Parser::JSON - parser for application/json
 =head1 SYNOPSIS
 
     use HTTP::Entity::Parser;
-    
+
     my $parser = HTTP::Entity::Parser->new;
     $parser->register('application/json','HTTP::Entity::Parser::JSON');
 

--- a/t/01_content_type/json.t
+++ b/t/01_content_type/json.t
@@ -8,6 +8,7 @@ use utf8;
 my $parser = HTTP::Entity::Parser::JSON->new();
 $parser->add('{');
 $parser->add('"hoge":["fuga","hige"],');
+$parser->add('"moji":{"kanji":{"ji":"\u5b57"}},');
 $parser->add('"\u306b\u307b\u3093\u3054":"\u65e5\u672c\u8a9e",');
 $parser->add('"moge":"muga"');
 $parser->add('}');
@@ -17,6 +18,7 @@ is_deeply(Hash::MultiValue->new(@$params)->as_hashref_multi,
   +{
     'hoge'     => [ 'fuga', 'hige' ],
     'moge'     => ['muga'],
+    'moji'     => [ { 'kanji' => { 'ji' => '字' } } ],
     Encode::encode_utf8('にほんご') => [Encode::encode_utf8('日本語')],
   });
 is_deeply $uploads, [];


### PR DESCRIPTION
Without this change, parsing a body like
``` json
{ "foo": { "bar": true } }
```
resulted in 
``` perl
{ foo => 'HASH(0xdeadbeef)' }
```
instead of
``` perl
{ foo => { bar => 1 } }
```
