### PR TITLE
Handle nested arrays

### DIFF
--- a/lib/HTTP/Entity/Parser/JSON.pm
+++ b/lib/HTTP/Entity/Parser/JSON.pm
@@ -23,12 +23,7 @@ sub finalize {
     my @params;
     if (ref $p eq 'HASH') {
         while (my ($k, $v) = each %$p) {
-            if (ref $v eq 'ARRAY') {
-                for (@$v) {
-                    push @params, encode_utf8($k) => ref($_) ? $_
-                                                             : encode_utf8($_);
-                }
-            } elsif (ref $v) {
+            if (ref $v) {
                 push @params, encode_utf8($k), $v;
             } else {
                 push @params, encode_utf8($k), encode_utf8($v);

--- a/lib/HTTP/Entity/Parser/JSON.pm
+++ b/lib/HTTP/Entity/Parser/JSON.pm
@@ -25,7 +25,8 @@ sub finalize {
         while (my ($k, $v) = each %$p) {
             if (ref $v eq 'ARRAY') {
                 for (@$v) {
-                    push @params, encode_utf8($k), encode_utf8($_);
+                    push @params, encode_utf8($k) => ref($_) ? $_
+                                                             : encode_utf8($_);
                 }
             } elsif (ref $v) {
                 push @params, encode_utf8($k), $v;

--- a/t/01_content_type/json.t
+++ b/t/01_content_type/json.t
@@ -10,6 +10,7 @@ $parser->add('{');
 $parser->add('"hoge":["fuga","hige"],');
 $parser->add('"moji":{"kanji":{"ji":"\u5b57"}},');
 $parser->add('"\u306b\u307b\u3093\u3054":"\u65e5\u672c\u8a9e",');
+$parser->add('"shallow":[{"deeper": "sunk"}],');
 $parser->add('"moge":"muga"');
 $parser->add('}');
 
@@ -19,6 +20,7 @@ is_deeply(Hash::MultiValue->new(@$params)->as_hashref_multi,
     'hoge'     => [ 'fuga', 'hige' ],
     'moge'     => ['muga'],
     'moji'     => [ { 'kanji' => { 'ji' => '字' } } ],
+    'shallow'  => [ { 'deeper' => 'sunk' } ],
     Encode::encode_utf8('にほんご') => [Encode::encode_utf8('日本語')],
   });
 is_deeply $uploads, [];

--- a/t/01_content_type/json.t
+++ b/t/01_content_type/json.t
@@ -15,13 +15,13 @@ $parser->add('"moge":"muga"');
 $parser->add('}');
 
 my ($params, $uploads) = $parser->finalize();
-is_deeply(Hash::MultiValue->new(@$params)->as_hashref_multi,
+is_deeply(Hash::MultiValue->new(@$params)->as_hashref_mixed,
   +{
     'hoge'     => [ 'fuga', 'hige' ],
-    'moge'     => ['muga'],
-    'moji'     => [ { 'kanji' => { 'ji' => '字' } } ],
+    'moge'     => 'muga',
+    'moji'     => { 'kanji' => { 'ji' => '字' } },
     'shallow'  => [ { 'deeper' => 'sunk' } ],
-    Encode::encode_utf8('にほんご') => [Encode::encode_utf8('日本語')],
+    Encode::encode_utf8('にほんご') => Encode::encode_utf8('日本語'),
   });
 is_deeply $uploads, [];
 


### PR DESCRIPTION
Hi,

This PR started out in exactly the same spirit as #11, but for nested arrays. The first two commits handle this.

As I was testing it, I also noticed that we were parsing JSON in such a way that we would lose information about whether any given JSON key's value was a hash or an array. This makes sense for parsing eg. form data, but for an application/json request it's not ideal. The second two commits fix this.