### PR TITLE
encode recursively nested Arrayrefs and Hashrefs in JSON

### DIFF
--- a/lib/HTTP/Entity/Parser/JSON.pm
+++ b/lib/HTTP/Entity/Parser/JSON.pm
@@ -23,14 +23,31 @@ sub finalize {
     my @params;
     if (ref $p eq 'HASH') {
         while (my ($k, $v) = each %$p) {
-            if (ref $v) {
-                push @params, encode_utf8($k), $v;
-            } else {
-                push @params, encode_utf8($k), encode_utf8($v);
-            }
+            push @params, _encode($k), _encode($v);
         }
     }
     return (\@params, []);
+}
+
+sub _encode {
+    my ($data) = @_;
+
+    if (ref $data eq "ARRAY") {
+        my @result;
+        for my $d (@$data) {
+            push @result, _encode($d);
+        }
+        return \@result;
+    }
+    elsif (ref $data eq "HASH") {
+        my %result;
+        while (my ($k, $v) = each %$data) {
+            $result{_encode($k)} = _encode($v);
+        }
+        return \%result;
+    }
+
+    return defined $data ? encode_utf8($data) : undef;
 }
 
 1;
@@ -64,5 +81,3 @@ Masahiro Nagano E<lt>kazeburo@gmail.comE<gt>
 Tokuhiro Matsuno E<lt>tokuhirom@gmail.comE<gt>
 
 =cut
-
-

--- a/t/01_content_type/json.t
+++ b/t/01_content_type/json.t
@@ -7,7 +7,7 @@ use utf8;
 
 my $parser = HTTP::Entity::Parser::JSON->new();
 $parser->add('{');
-$parser->add('"hoge":["fuga","hige"],');
+$parser->add('"hoge":["fuga","hige","\u306b\u307b\u3093\u3054"],');
 $parser->add('"moji":{"kanji":{"ji":"\u5b57"}},');
 $parser->add('"\u306b\u307b\u3093\u3054":"\u65e5\u672c\u8a9e",');
 $parser->add('"shallow":[{"deeper": "sunk"}],');
@@ -17,9 +17,9 @@ $parser->add('}');
 my ($params, $uploads) = $parser->finalize();
 is_deeply(Hash::MultiValue->new(@$params)->as_hashref_mixed,
   +{
-    'hoge'     => [ 'fuga', 'hige' ],
+    'hoge'     => [ 'fuga', 'hige', Encode::encode_utf8('にほんご') ],
     'moge'     => 'muga',
-    'moji'     => { 'kanji' => { 'ji' => '字' } },
+    'moji'     => { 'kanji' => { 'ji' => Encode::encode_utf8('字') } },
     'shallow'  => [ { 'deeper' => 'sunk' } ],
     Encode::encode_utf8('にほんご') => Encode::encode_utf8('日本語'),
   });


### PR DESCRIPTION
Before #11, each element of an Arrayref were encoded. But it is not encoded now.
So, I modified it to encode recursively the contents of Arrayrefs (and also nested Hashrefs).